### PR TITLE
Use aidl3 instead of aidl2

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ which details the binder nodes and aidl version used for the waydroid release.
 A typical file looks like:
 ```
   [Protocol]
-  /dev/puddlejumper = aidl2
-  /dev/vndpuddlejumper = aidl2
+  /dev/puddlejumper = aidl3
+  /dev/vndpuddlejumper = aidl3
   /dev/hwpuddlejumper = hidl
 
   [ServiceManager]
-  /dev/puddlejumper = aidl2
-  /dev/vndpuddlejumper = aidl2
+  /dev/puddlejumper = aidl3
+  /dev/vndpuddlejumper = aidl3
   /dev/hwpuddlejumper = hidl
 ```
 However, different devices have different binder files, or they may be in another location such as /dev/binderfs/.

--- a/config/anbox-hybris.conf
+++ b/config/anbox-hybris.conf
@@ -1,10 +1,10 @@
 [Protocol]
-/dev/puddlejumper = aidl2
-/dev/vndpuddlejumper = aidl2
+/dev/puddlejumper = aidl3
+/dev/vndpuddlejumper = aidl3
 /dev/hwpuddlejumper = hidl
 
 [ServiceManager]
-/dev/puddlejumper = aidl2
-/dev/vndpuddlejumper = aidl2
+/dev/puddlejumper = aidl3
+/dev/vndpuddlejumper = aidl3
 /dev/hwpuddlejumper = hidl
 

--- a/config/anbox-mainline.conf
+++ b/config/anbox-mainline.conf
@@ -1,10 +1,10 @@
 [Protocol]
-/dev/binder = aidl2
-/dev/vndbinder = aidl2
+/dev/binder = aidl3
+/dev/vndbinder = aidl3
 /dev/hwbinder = hidl
 
 [ServiceManager]
-/dev/binder = aidl2
-/dev/vndbinder = aidl2
+/dev/binder = aidl3
+/dev/vndbinder = aidl3
 /dev/hwbinder = hidl
 


### PR DESCRIPTION
The newest OTA images for Waydroid are based on LineageOS 18.1 which is on API level 30. This API level requires the use of aidl3 instead of aidl2.