### PR TITLE
Remove apparmor reference in config_3 at on installed working config

### DIFF
--- a/rpm/0002-Remove-apparmor-reference-in-config_3.patch
+++ b/rpm/0002-Remove-apparmor-reference-in-config_3.patch
@@ -1,0 +1,24 @@
+From 386cf050b93b63fd83de43c5687c52f70383b8c0 Mon Sep 17 00:00:00 2001
+From: "Vlad G." <b100dian@gmail.com>
+Date: Sun, 23 Jun 2024 17:22:40 +0300
+Subject: [PATCH] Remove apparmor reference in config_3
+
+---
+ data/configs/config_3 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/configs/config_3 b/data/configs/config_3
+index 3c82226..21c13d9 100644
+--- a/data/configs/config_3
++++ b/data/configs/config_3
+@@ -1,6 +1,6 @@
+ lxc.uts.name = waydroid
+ 
+-lxc.apparmor.profile = unconfined
++#lxc.apparmor.profile = unconfined
+ lxc.seccomp.profile = /var/lib/waydroid/lxc/waydroid/waydroid.seccomp
+ 
+ lxc.no_new_privs = 1
+-- 
+2.45.2
+

--- a/rpm/waydroid.spec
+++ b/rpm/waydroid.spec
@@ -1,5 +1,5 @@
 Name:           waydroid
-Version:        1.3.4
+Version:        1.3.4+git1
 Release:        1
 Summary:        Container-based approach to boot a full Android system
 License:        GPLv3

--- a/rpm/waydroid.spec
+++ b/rpm/waydroid.spec
@@ -7,6 +7,7 @@ URL:            https://waydro.id/
 BuildArch:      noarch
 Source0:        %{name}-%{version}.tar.gz
 Patch0:         0001-disable-user-manager.patch
+Patch1:         0002-Remove-apparmor-reference-in-config_3.patch
 
 BuildRequires:  systemd
 BuildRequires:  desktop-file-utils
@@ -88,6 +89,11 @@ desktop-file-install config/waydroid.desktop
 
 %clean
 rm -rf $RPM_BUILD_ROOT
+
+%pre
+if [ $1 == 2 ]; then
+  sed -i '/apparmor/d' %{_sharedstatedir}/waydroid/lxc/waydroid/config
+fi
 
 %post
 systemctl daemon-reload

--- a/rpm/waydroid.spec
+++ b/rpm/waydroid.spec
@@ -92,7 +92,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %pre
 if [ $1 == 2 ]; then
-  sed -i '/apparmor/d' %{_sharedstatedir}/waydroid/lxc/waydroid/config
+  sed -i '/apparmor/d' %{_sharedstatedir}/waydroid/lxc/waydroid/config || :
 fi
 
 %post


### PR DESCRIPTION
Should fix https://github.com/sailfishos-open/waydroid/issues/30

There are two things:
- Removing the existing reference to apparmor in the working config
- Removing the apparmor reference used in config_3 which is [merged](https://github.com/waydroid/waydroid/blob/068a143be99bf57fe649395ad9d95ef966fc49d8/tools/helpers/lxc.py#L152) at waydroid init