### PR TITLE
Update waydroid to 1.4.2

### DIFF
--- a/rpm/waydroid.spec
+++ b/rpm/waydroid.spec
@@ -74,6 +74,7 @@ mkdir -p %{buildroot}/var/lib/
 ln -sf /home/waydroid %{buildroot}/var/lib/waydroid
 mkdir -p %{buildroot}/usr/bin
 ln -sf /opt/waydroid/waydroid.py %{buildroot}/usr/bin/waydroid
+install -D -m644 upstream/dbus/id.waydro.Container.conf %{buildroot}%{_datadir}/dbus-1/system.d/id.waydro.Container.conf
 
 install -D -m644 config/anbox-hybris.conf %{buildroot}/etc/gbinder.d/anbox-hybris.conf
 install -D -m644 config/anbox-mainline.conf %{buildroot}/etc/gbinder.d/anbox-mainline.conf
@@ -108,6 +109,7 @@ systemctl enable waydroid-container
 %{_sysconfdir}/modules-load.d/waydroid.conf
 %{_bindir}/waydroid
 %{_unitdir}/waydroid-container.service
+%{_datadir}/dbus-1/system.d/id.waydro.Container.conf
 
 %files settings
 %defattr(-,root,root,-)

--- a/rpm/waydroid.spec
+++ b/rpm/waydroid.spec
@@ -1,5 +1,5 @@
 Name:           waydroid
-Version:        1.3.4+git1
+Version:        1.4.2
 Release:        1
 Summary:        Container-based approach to boot a full Android system
 License:        GPLv3


### PR DESCRIPTION
Update waydroid to 1.4.2 - this includes installing a dbus file according to https://t.me/WayDroid/129861 but instead of the advice to create it it is copied from upstream and instead of using /etc we're using /usr/share.
