### PR TITLE
Fix upgrade from pre 1.4 to 1.4.x

### DIFF
--- a/rpm/waydroid.spec
+++ b/rpm/waydroid.spec
@@ -102,7 +102,7 @@ if [ $1 == 2 ]; then
 # Existing config might have apparmor reference, remove it on upgrade since SailfishOS doesn't use apparmor
   sed -i '/apparmor/d' %{_sharedstatedir}/waydroid/lxc/waydroid/config || :
 # Existing config pre 1.4 might not have config_session included. Append it if not, after config_nodes.
-  grep config_session %{_sharedstatedir}/waydroid/lxc/waydroid/config || sed -e '/config_nodes/a\' -e 'lxc.include = %{_sharedstatedir}/waydroid/lxc/waydroid/config_session' %{_sharedstatedir}/waydroid/lxc/waydroid/config
+  grep config_session %{_sharedstatedir}/waydroid/lxc/waydroid/config || sed -e '/config_nodes/a\' -e 'lxc.include = %{_sharedstatedir}/waydroid/lxc/waydroid/config_session' -i %{_sharedstatedir}/waydroid/lxc/waydroid/config
 fi
 
 %post

--- a/rpm/waydroid.spec
+++ b/rpm/waydroid.spec
@@ -99,7 +99,10 @@ rm -rf $RPM_BUILD_ROOT
 
 %pre
 if [ $1 == 2 ]; then
+# Existing config might have apparmor reference, remove it on upgrade since SailfishOS doesn't use apparmor
   sed -i '/apparmor/d' %{_sharedstatedir}/waydroid/lxc/waydroid/config || :
+# Existing config pre 1.4 might not have config_session included. Append it if not, after config_nodes.
+  grep config_session %{_sharedstatedir}/waydroid/lxc/waydroid/config || sed -e '/config_nodes/a\' -e 'lxc.include = %{_sharedstatedir}/waydroid/lxc/waydroid/config_session' %{_sharedstatedir}/waydroid/lxc/waydroid/config
 fi
 
 %post


### PR DESCRIPTION
This commit: https://github.com/waydroid/waydroid/commit/c49dfd272d994b1cdaa14107fee66be84b80c06b only exists in versions 1.4.0 and later of waydroid packaging.

If you have an existing waydroid config, only config_nodes (not config_session) might be included.

This tries to fix this